### PR TITLE
Fixed link to Backendless.

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
         <article id="backendless">
           <h3>Backendless</h3>
           <p>
-            <a href="http://hood.ie">Backendless</a> adds features for user accounts.
+            <a href="http://backendless.com/">Backendless</a> adds features for user accounts.
           </p>
           <p>
             <a href="nobackend-examples/backendless/index.html">open app</a>


### PR DESCRIPTION
It was pointing to Hood.ie instead.
